### PR TITLE
Do not publish .babelrc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 node_modules
 example
 *.log
+.babelrc
 
 # don't ignore .npmignore files
 !.npmignore


### PR DESCRIPTION
A published `.babelrc` file creates issues with babel's "lookup behavior": https://stackoverflow.com/questions/43727228/ignore-babelrc-relative-to-a-node-module

Errors look like this: https://github.com/rollup/rollup-plugin-node-resolve/issues/27

The particular error I get is:

```
  Error: ./node_modules/react-katex/src/index.js
  Module build failed: Error: Couldn't find preset "es2015-rollup" relative to directory "/var/www/current/var/@coursehero-components/study-guides/node_modules/react-katex"
  at /var/www/current/var/@coursehero-components/study-guides/node_modules/babel-core/lib/transformation/file/options/option-manager.js:293:19
  at Array.map (<anonymous>)
  at OptionManager.resolvePresets (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-core/lib/transformation/file/options/option-manager.js:275:20)
  at OptionManager.mergePresets (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-core/lib/transformation/file/options/option-manager.js:264:10)
  at OptionManager.mergeOptions (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-core/lib/transformation/file/options/option-manager.js:249:14)
  at OptionManager.init (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
  at File.initOptions (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-core/lib/transformation/file/index.js:212:65)
  at new File (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-core/lib/transformation/file/index.js:135:24)
  at Pipeline.transform (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
  at transpile (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-loader/lib/index.js:50:20)
  at Object.module.exports (/var/www/current/var/@coursehero-components/study-guides/node_modules/babel-loader/lib/index.js:175:20)
```