### PR TITLE
Update React peerDependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "peerDependencies": {
     "prop-types": "^15.5.10",
-    "react": "^15.3.2"
+    "react": "^15.3.2 || ^16.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.25.0",


### PR DESCRIPTION
I haven't _fully_ tested this (nor looked through the source code to make sure it's 100% compatible), but this library has been working well for me with React 16. Thanks!

---

Related: https://github.com/talyssonoc/react-katex/issues/33#issuecomment-375124999

This issue claims that the new version works with 16. Perhaps updating `peerDependencies` was missed with that release.