### PR TITLE
Allow passing arbitrary options to KaTeX

### DIFF
--- a/src/createMathComponent.js
+++ b/src/createMathComponent.js
@@ -40,7 +40,8 @@ const createMathComponent = (Component, { displayMode }) => {
       return KaTeX.renderToString(props[this.usedProp], {
         displayMode,
         errorColor,
-        throwOnError: !!renderError
+        throwOnError: !!renderError,
+        ...this.props.katexOptions
       });
     }
 
@@ -63,8 +64,13 @@ const createMathComponent = (Component, { displayMode }) => {
   MathComponent.propTypes = {
     children: PropTypes.string,
     errorColor: PropTypes.string,
+    katexOptions: PropTypes.object,
     math: PropTypes.string,
     renderError: PropTypes.func
+  };
+
+  MathComponent.defaultProps = {
+    katexOptions: {}
   };
 
   return MathComponent;


### PR DESCRIPTION
https://github.com/Khan/KaTeX#rendering-options

Personally, I wanted to set the maxSize option to KaTeX, but I figured that there are a lot of other options to KaTeX that a user might want to pass in, and it would be tedious to try to keep this component in sync with any options that KaTeX adds. So I thought this would be a good approach.

We could also use PropTypes.shape and specify the currently known KaTeX options, and that way if any new options are added a user can still pass them in via an object, and the worst case is that they get a warning from PropTypes.

Let me know what you think. Thanks!