### PR TITLE
Added UNSAFE_ to componentWillReceiveProps

### DIFF
--- a/src/createMathComponent.js
+++ b/src/createMathComponent.js
@@ -12,7 +12,7 @@ const createMathComponent = (Component, { displayMode }) => {
       this.state = this.createNewState(null, props);
     }
 
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps() {
       this.setState(this.createNewState);
     }
 


### PR DESCRIPTION
componentWillReceiveProps will be deprecated in react 17. After that only UNSAFE_componentWillReceiveProps will work. This change prepares for react 17 and up compatibility. 