### PR TITLE
Fix double rendering of mathml and html

### DIFF
--- a/packages/react-katex/src/index.jsx
+++ b/packages/react-katex/src/index.jsx
@@ -41,6 +41,7 @@ const createMathComponent = (Component, { displayMode }) => {
         const html = KaTeX.renderToString(formula, {
           displayMode,
           errorColor,
+          output: "mathml",
           throwOnError: !!renderError,
         });
 


### PR DESCRIPTION
Pull request to fix the double rendering of both mathml and html without the `output` argument.

[Katex](https://katex.org/docs/options.html#docsNav) now states that `htmlAndMathml` is the default value for the `output` parameter which causes the rendering of both the html and mathml

<img width="294" alt="Screenshot 2024-03-04 at 11 39 30 PM" src="https://github.com/talyssonoc/react-katex/assets/15256744/4d9c1a77-f6f6-4ecc-a625-f46b301fed7a">
