### PR TITLE
Update React peerDependency range #2

### DIFF
--- a/packages/react-katex/package.json
+++ b/packages/react-katex/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.8.1",
-    "react": ">=15.3.2 <=18"
+    "react": ">=15.3.2 <20"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.9",


### PR DESCRIPTION
This PR updates the react peerDependency to allow React 19 ("react": ">=15.3.2 <20").

This is a follow-up to [#39](https://github.com/talyssonoc/react-katex/pull/39), and it also addresses [#86](https://github.com/talyssonoc/react-katex/issues/86), where support for newer versions of React is requested.

Updating this range allows projects using React 19 to install react-katex without peer dependency warnings


## Test Results
```
--------------------|---------|----------|---------|---------|-------------------
File                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------|---------|----------|---------|---------|-------------------
All files           |    98.8 |      100 |     100 |   98.68 |                   
 src                |      96 |      100 |     100 |   95.65 |                   
  index.jsx         |      96 |      100 |     100 |   95.65 | 53                
 tests              |     100 |      100 |     100 |     100 |                   
  sharedExamples.js |     100 |      100 |     100 |     100 |                   
--------------------|---------|----------|---------|---------|-------------------

Test Suites: 2 passed, 2 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        1.828 s
Ran all test suites.
```
You can view the full test log for this PR [here](https://github.com/shiueo/react-katex/actions/runs/14613836267/job/40997412977). (Tested via Github CI.)

I have been using React 19 with `react-katex` for several months without encountering any issues!